### PR TITLE
Add a name and description to spots in maps.me file

### DIFF
--- a/lib/hitchspots/templates/mm_template.xml.erb
+++ b/lib/hitchspots/templates/mm_template.xml.erb
@@ -1,10 +1,20 @@
 <%
 def color(rating)
   case rating
-  when "0", "5" then "#placemark-red"
-  when "4"      then "#placemark-orange"
+  when "1", "2" then "#placemark-green"
   when "3"      then "#placemark-yellow"
-  else "#placemark-green"
+  when "4"      then "#placemark-orange"
+  else               "#placemark-red"
+  end
+end
+def hitchability(rating)
+  case rating
+  when "1" then "Very Good"
+  when "2" then "Good"
+  when "3" then "Medium"
+  when "4" then "Bad"
+  when "5" then "Very Bad"
+  else          "Unknown"
   end
 end
 %>
@@ -43,7 +53,10 @@ end
   <visibility>1</visibility>
   <% spots.each_with_index do |spot, i| %>
   <Placemark>
-    <name><%= "Spot #{i}" %></name>
+    <name><%= spot.fetch("encoded_name", nil) || "Spot #{spot['hw_id']}" %></name>
+    <description>Hitchability: <%= hitchability(spot["rating"]) %><% if spot.fetch("encoded_desc", nil) %>
+
+<%= spot["encoded_desc"] %><% end %></description>
     <TimeStamp><when><%= time %></when></TimeStamp>
     <styleUrl><%= color(spot["rating"]) %></styleUrl>
     <Point><coordinates><%= spot["lon"] %>,<%= spot["lat"] %></coordinates></Point>


### PR DESCRIPTION
The main goal of this PR is to add in MAPS.me file:

- The locality as pin name
- The Hitchability (rating in words) and the en_UK description as pin description

en_UK: most pins have a en_UK description if they have a description at all, I did not bother searching for another one if English is not there.

If no locality, name is "Spot" + spot id (hitchwiki id)
If no description, only show Hitchability

***********

I had to fix the encoding in the database. The problem was that MAPS.me would ignore an entire collection of pins if the encoding is not good. And for some reason, it did not work to fix the encoding on the fly while building the KML file. And I could not find how to solve it, so I decided to fix the encoding upstream.

New records will be encoded before insert, updated ones won't.

Here is the code to execute manually in IRB to fix existing records:

```ruby
def symbolize(string_keys)
  Hash[
    string_keys.map do |key, value|
      [key.to_sym, (value.is_a?(Hash) ? symbolize(value) : value )]
    end
  ]
end

def fix_encoding(params)
  params.tap do |params|
    locality = params.fetch(:location, {}).fetch(:locality, nil)

    if locality
      begin
        new_locality = locality.encode("Windows-1252").force_encoding("utf-8")
        params[:encoded_name] = new_locality
      rescue Encoding::UndefinedConversionError
        # do nothing, ignore encoding correction
      end
    end

    desc = params.fetch(:description, {}).fetch(:en_UK, {}).fetch(:description, nil)

    if desc
      begin
        new_desc = desc.encode("Windows-1252").force_encoding("utf-8")
        params[:encoded_desc] = new_desc
      rescue Encoding::UndefinedConversionError
        # do nothing, ignore encoding correction
      end
    end
  end
end

# Re-encode existing data:
Hitchspots::Spot.all.each do |spot|
  temp_spot = symbolize(spot)
  temp_spot[:id] = temp_spot[:hw_id]
  temp_spot.delete :_id

  new_spot = Hitchspots::Spot.new(fix_encoding(temp_spot))
  begin
    new_spot.save
  rescue ArgumentError
    # don't save
  end
end
```