### PR TITLE
Update data whose rating has changed

### DIFF
--- a/lib/tasks/hitchwiki.rake
+++ b/lib/tasks/hitchwiki.rake
@@ -29,5 +29,18 @@ namespace :hitchwiki do
       hitchspot = DB::Spot.new(id: hw_id)
       hitchspot.destroy
     end
+
+    # update spots whose rating have changed
+    # [[id, rating], [id, rating]]
+    db_ratings = DB::Spot::Collection
+                   .find.projection( "raw.rating" => 1, "raw.id" => 1, _id: 0 )
+                   .to_a.map { |s| [ s["raw"]["id"], s["raw"]["rating"] ] }
+    hw_ratings = hitchwiki_spots.map { |s| [s[:id], s[:rating]] }
+
+    (hw_ratings - db_ratings).each do |id, rating|
+      detailed_spot = Hitchspots::Hitchwiki.spot(id)
+      hitchspot = DB::Spot.new(detailed_spot)
+      hitchspot.save
+    end
   end
 end

--- a/test/db_spot_test.rb
+++ b/test/db_spot_test.rb
@@ -2,18 +2,37 @@ require_relative "test_helper"
 require "./app"
 
 class DbSpotTest < Minitest::Test
+  def setup
+    DB::Spot::Collection.delete_many
+  end
+
   def test_re_encoding
-    spot = ::DB::Spot.new(id: "1", lat: "46.7635", lon: "6.643722",
-                          location: { locality: "KÃ¶niz" },
-                          description: {
-                            en_UK: {
-                              description: "TimiÈ™oara is a nice place"
-                            }
-                          })
+    spot = DB::Spot.new(id: "1", lat: "46.7635", lon: "6.643722",
+                        location: { locality: "KÃ¶niz" },
+                        description: {
+                          en_UK: {
+                            description: "TimiÈ™oara is a nice place"
+                          }
+                        })
 
     sanitized = spot.data[:sanitized]
 
-    assert_equal sanitized[:location][:locality], "Köniz"
-    assert_equal sanitized[:description][:en_UK][:description], "Timișoara is a nice place"
+    assert_equal "Köniz", sanitized[:location][:locality]
+    assert_equal "Timișoara is a nice place", sanitized[:description][:en_UK][:description]
+  end
+
+  def test_update
+    spot = DB::Spot.new(id: "1", lat: "3.444", location: { locality: "KÃ¶niz" })
+
+    spot.save
+
+    spot = DB::Spot.new(id: "1", location: { locality: "Yverdon" })
+
+    spot.save
+
+    retrieved = DB::Spot::Collection.find("raw.id" => "1").to_a.first
+
+    assert_equal "Yverdon", retrieved["sanitized"]["location"]["locality"]
+    assert_equal 1, DB::Spot.all.size
   end
 end


### PR DESCRIPTION
#About

Augment `hitchwiki:refresh` rake task to update spots whose rating has changed.

Need heroku cron job or other async job to execute `rake hitchwiki:refresh` regularly.

Closes #10 