### PR TITLE
Feature: add route in the bookmarks file if present (trip)

### DIFF
--- a/lib/hitchspots/templates/mm_template.xml.erb
+++ b/lib/hitchspots/templates/mm_template.xml.erb
@@ -49,8 +49,20 @@ end
       </Icon>
     </IconStyle>
   </Style>
-  <name>HitchSpots: <%= title %></name>
+  <Style id="line-black">
+    <LineStyle>
+        <color>ff000000</color>
+    </LineStyle>
+  </Style>
+  <name>Hitchspots: <%= title %></name>
   <visibility>1</visibility>
+  <% if defined?(coordinates) && coordinates&.any? %>
+  <Placemark>
+    <name><%= title %></name>
+    <styleUrl>#line-black</styleUrl>
+    <LineString><coordinates><%= coordinates.map { |internal| internal.join(",") }.join("\n") %></coordinates></LineString>
+  </Placemark>
+  <% end %>
   <% spots.each_with_index do |spot, i| %>
   <Placemark>
     <name><%= spot.fetch("location", {}).fetch("locality", nil) || "Spot #{spot['id']}" %></name>

--- a/lib/hitchspots/trip.rb
+++ b/lib/hitchspots/trip.rb
@@ -21,7 +21,7 @@ module Hitchspots
 
       case format
       when :json then spots.to_json
-      when :kml  then build_kml(spots)
+      when :kml  then build_kml(spots, coordinates: coords)
       else            spots
       end
     end
@@ -74,10 +74,11 @@ module Hitchspots
       [area_lat_min, area_lat_max, area_lon_min, area_lon_max]
     end
 
-    def build_kml(spots)
-      title = "#{from.short_name} - #{to.short_name}"
-      spots = spots
-      time  = Time.now.utc.iso8601
+    def build_kml(spots, coordinates: nil)
+      title       = "#{from.short_name} - #{to.short_name}"
+      spots       = spots
+      coordinates = coordinates
+      time        = Time.now.utc.iso8601
       ERB.new(File.read("#{__dir__}/templates/mm_template.xml.erb"), 0, ">")
          .result(binding)
     end


### PR DESCRIPTION
# About

New feature: add route in the bookmarks file if present (trip). A kml file can contain a `<LineString>`, which takes an array of coordinates as argument and draws a line between each point. [Documentation](https://developers.google.com/kml/documentation/kmlreference#linestring)

For trip feature, we already have the coordinates that we get from mapbox, it's nice to also add the route in the kml file to be seen in maps.me like in the picture below:

![screenshot_20180929-144058](https://user-images.githubusercontent.com/9248448/46246011-c4bf2600-c3f7-11e8-8b3c-39a9ab0bc31e.png)
