### PR TITLE
API change for trip endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,4 +19,4 @@ Layout/MultilineMethodCallIndentation:
 Lint/HandleExceptions:
   Enabled: false
 Metrics/AbcSize:
-  Max: 16
+  Max: 16.1

--- a/app.rb
+++ b/app.rb
@@ -59,6 +59,7 @@ get "/trip" do
 
     maps_me_kml = trip.spots(format: :kml)
 
+    response.headers["Warning"] = "299 hitchspots.me/trip \"Deprecated\""
     content_type "application/vnd.google-earth.kml+xml"
     attachment trip.file_name(format: :kml)
     maps_me_kml

--- a/lib/hitchspots/coordinate.rb
+++ b/lib/hitchspots/coordinate.rb
@@ -8,15 +8,34 @@ module Hitchspots
     # @param [Place] finish_location A Place object to get geoloc for
     #
     # @return [Array] Array of coordinates: [[lon1, lat1], [lon2, lat2], ...]
-    def self.for_trip(start_location, finish_location, api: :osrm)
+    def self.for_deprecated_trip(start_location, finish_location, api: :osrm)
       start_geo  = find_geolocation(start_location)
       finish_geo = find_geolocation(finish_location)
 
       case api
       when :osrm
-        osrm_coordinates(start_geo, finish_geo)
+        osrm_coordinates([start_geo, finish_geo])
       when :mapbox
-        mapbox_coordinates(start_geo, finish_geo)
+        mapbox_coordinates([start_geo, finish_geo])
+      else
+        raise Error, "API wrapper #{api} not implemented"
+      end
+    end
+
+    # Using OSRM API, fetch coordinates for a trip having a start place and
+    # finish place
+    #
+    # @param [Array<Place>] locations Array of Place objects to get geoloc for
+    #
+    # @return [Array] Array of coordinates: [[lon1, lat1], [lon2, lat2], ...]
+    def self.for_trip(locations, api: :osrm)
+      geolocs = locations.map { |place| find_geolocation(place) }
+
+      case api
+      when :osrm
+        osrm_coordinates(geolocs)
+      when :mapbox
+        mapbox_coordinates(geolocs)
       else
         raise Error, "API wrapper #{api} not implemented"
       end
@@ -32,8 +51,8 @@ module Hitchspots
 
     # Rubocop bug: https://github.com/bbatsov/rubocop/issues/4431
     # rubocop:disable Layout/MultilineMethodCallIndentation
-    private_class_method def self.osrm_coordinates(start_geo, finish_geo)
-      trip = Osrm.trip(start_geo, finish_geo)
+    private_class_method def self.osrm_coordinates(geolocations)
+      trip = Osrm.trip(geolocations)
       # TODO: Not found should not be an exception
       raise NotFound, "No route found" if trip[:code] == "NoRoute"
 
@@ -46,8 +65,8 @@ module Hitchspots
 
     # Rubocop bug: https://github.com/bbatsov/rubocop/issues/4431
     # rubocop:disable Layout/MultilineMethodCallIndentation
-    private_class_method def self.mapbox_coordinates(start_geo, finish_geo)
-      trip = Mapbox.trip(start_geo, finish_geo)
+    private_class_method def self.mapbox_coordinates(geolocations)
+      trip = Mapbox.trip(geolocations)
       # TODO: Not found should not be an exception
       raise NotFound, "No route found" if trip[:code] == "NoRoute"
 

--- a/lib/hitchspots/deprecated_trip.rb
+++ b/lib/hitchspots/deprecated_trip.rb
@@ -1,0 +1,88 @@
+require "json"
+require "erb"
+require "time"
+
+module Hitchspots
+  module Deprecated
+    # Hitchhiking trip for which we would like to get the Hitchwiki maps spots
+    class Trip
+      attr_reader :from, :to
+
+      # @param [Place] from Place object, origin of Trip
+      # @param [Place] to   Place object, destination of Trip
+      def initialize(from:, to:)
+        @from = from
+        @to   = to
+      end
+
+      def spots(format: nil)
+        coords = Coordinate.for_deprecated_trip(from, to, api: :mapbox)
+        bounds = areas(coords)
+        spots  = find_spots(bounds)
+
+        case format
+        when :json then spots.to_json
+        when :kml  then build_kml(spots, coordinates: coords)
+        else            spots
+        end
+      end
+
+      # Example: paris-berlin.kml
+      def file_name(format: :txt)
+        "#{from.short_name.downcase.gsub(/[^a-z]/, '_')}-"\
+        "#{to.short_name.downcase.gsub(/[^a-z]/, '_')}.#{format}"
+      end
+
+      private
+
+      def areas(coordinates)
+        zones = []
+        coordinates.each_with_index do |(this_lon, this_lat), i|
+          next if i == 0
+
+          prev_lon, prev_lat = *coordinates[i - 1]
+
+          # Add about 10km on each side to overlap
+          zones << [[this_lat, prev_lat].min - 0.1,
+                    [this_lat, prev_lat].max + 0.1,
+                    [this_lon, prev_lon].min - 0.1,
+                    [this_lon, prev_lon].max + 0.1]
+        end
+        zones
+      end
+
+      def find_spots(zones)
+        all_spots = Spot.in_area(*area_containing_zones(zones))
+
+        spots = zones.map do |lat_min, lat_max, lon_min, lon_max|
+          all_spots.select do |spot|
+            within_lat = spot["lat"] >= lat_min && spot["lat"] <= lat_max
+            within_lon = spot["lon"] >= lon_min && spot["lon"] <= lon_max
+
+            within_lat && within_lon
+          end
+        end
+
+        spots.flatten.uniq { |spot| spot["id"] }
+      end
+
+      def area_containing_zones(zones)
+        area_lat_min = zones.map { |z| z[0] }.min
+        area_lat_max = zones.map { |z| z[1] }.max
+        area_lon_min = zones.map { |z| z[2] }.min
+        area_lon_max = zones.map { |z| z[3] }.max
+
+        [area_lat_min, area_lat_max, area_lon_min, area_lon_max]
+      end
+
+      def build_kml(spots, coordinates: nil)
+        title       = "#{from.short_name} - #{to.short_name}"
+        spots       = spots
+        coordinates = coordinates
+        time        = Time.now.utc.iso8601
+        ERB.new(File.read("#{__dir__}/templates/mm_template.xml.erb"), 0, ">")
+           .result(binding)
+      end
+    end
+  end
+end

--- a/lib/hitchspots/mapbox.rb
+++ b/lib/hitchspots/mapbox.rb
@@ -9,14 +9,13 @@ module Hitchspots
     # Using Directions service, fetch trip data knowing start and finish locations.
     # doc: https://www.mapbox.com/api-documentation/#retrieve-directions
     #
-    # @param [Hash] start  Coordidates hash like { lat: 1.23455, lon: 9.87654 }
-    # @param [Hash] finish Coordidates hash like { lat: 1.23455, lon: 9.87654 }
+    # @param [Array<Hash>] geolocs Array of Coordidates hash like { lat: 1.23455, lon: 9.87654 }
     #
     # @return [Hash] A Trip object from Mapbox
-    def self.trip(start, finish)
+    def self.trip(geolocs)
       base_url = "https://api.mapbox.com/directions/v5/mapbox/driving/"
-      uri      = URI("#{base_url}#{start[:lon]},#{start[:lat]};"\
-                     "#{finish[:lon]},#{finish[:lat]}")
+      points   = geolocs.map { |geoloc| "#{geoloc[:lon]},#{geoloc[:lat]}" }.join(";")
+      uri      = URI("#{base_url}#{points}")
 
       uri.query = URI.encode_www_form(geometries: "geojson",
                                       access_token: ENV["MAPBOX_TOKEN"])

--- a/lib/hitchspots/osrm.rb
+++ b/lib/hitchspots/osrm.rb
@@ -9,14 +9,13 @@ module Hitchspots
     # Using Trip service, fetch trip data knowing start and finish locations.
     # doc: http://project-osrm.org/docs/v5.10.0/api/#trip-service
     #
-    # @param [Hash] start  Coordidates hash like { lat: 1.23455, lon: 9.87654 }
-    # @param [Hash] finist Coordidates hash like { lat: 1.23455, lon: 9.87654 }
+    # @param [Array<Hash>] geolocs Array of Coordidates hash like { lat: 1.23455, lon: 9.87654 }
     #
     # @return [Hash] A Trip object from OSRM
-    def self.trip(start, finish)
+    def self.trip(geolocs)
       base_url = "https://router.project-osrm.org/trip/v1/driving/"
-      uri      = URI("#{base_url}#{start[:lon]},#{start[:lat]};"\
-                     "#{finish[:lon]},#{finish[:lat]}")
+      points   = geolocs.map { |geoloc| "#{geoloc[:lon]},#{geoloc[:lat]}" }.join(";")
+      uri      = URI("#{base_url}#{points}")
 
       uri.query = URI.encode_www_form(source: "first",
                                       destination: "last",

--- a/lib/hitchspots/trip.rb
+++ b/lib/hitchspots/trip.rb
@@ -5,17 +5,15 @@ require "time"
 module Hitchspots
   # Hitchhiking trip for which we would like to get the Hitchwiki maps spots
   class Trip
-    attr_reader :from, :to
+    attr_reader :places
 
-    # @param [Place] from Place object, origin of Trip
-    # @param [Place] to   Place object, destination of Trip
-    def initialize(from:, to:)
-      @from = from
-      @to   = to
+    # @param [Array<Place>] Array of Place objects, from origin to end of trip with via points
+    def initialize(places:)
+      @places = places
     end
 
     def spots(format: nil)
-      coords = Coordinate.for_trip(from, to, api: :mapbox)
+      coords = Coordinate.for_trip(places, api: :mapbox)
       bounds = areas(coords)
       spots  = find_spots(bounds)
 
@@ -28,8 +26,8 @@ module Hitchspots
 
     # Example: paris-berlin.kml
     def file_name(format: :txt)
-      "#{from.short_name.downcase.gsub(/[^a-z]/, '_')}-"\
-      "#{to.short_name.downcase.gsub(/[^a-z]/, '_')}.#{format}"
+      "#{places.first.short_name.downcase.gsub(/[^a-z]/, '_')}-"\
+      "#{places.last.short_name.downcase.gsub(/[^a-z]/, '_')}.#{format}"
     end
 
     private
@@ -75,7 +73,7 @@ module Hitchspots
     end
 
     def build_kml(spots, coordinates: nil)
-      title       = "#{from.short_name} - #{to.short_name}"
+      title       = "#{places.first.short_name} - #{places.last.short_name}"
       spots       = spots
       coordinates = coordinates
       time        = Time.now.utc.iso8601

--- a/presenters/home_presenter.rb
+++ b/presenters/home_presenter.rb
@@ -5,12 +5,14 @@ class HomePresenter
 
   def trip
     @trip ||= Hitchspots::Trip.new(
-      from: Hitchspots::Place.new(params[:from],
-                                  lat: params[:from_lat],
-                                  lon: params[:from_lon]),
-      to:   Hitchspots::Place.new(params[:to],
-                                  lat: params[:to_lat],
-                                  lon: params[:to_lon])
+      places: [
+        Hitchspots::Place.new(params.dig(:places, "0", :name),
+                              lat: params.dig(:places, "0", :lat),
+                              lon: params.dig(:places, "0", :lon)),
+        Hitchspots::Place.new(params.dig(:places, "1", :name),
+                              lat: params.dig(:places, "1", :lat),
+                              lon: params.dig(:places, "1", :lon))
+      ]
     )
   end
 

--- a/public/js/hitchspots2.js
+++ b/public/js/hitchspots2.js
@@ -1,35 +1,31 @@
 $(document).ready(function() {
+  //////////////
+  // Geocoding
+  //////////////
   var engine = new PhotonAddressEngine();
 
-  $('#from').typeahead(null, {
-    source: engine.ttAdapter(),
-    displayKey: 'description'
+  $("[data-behaviour~='geocode']").each(function(_, el) {
+    var index = $(el).attr('data-place-index');
+
+    $('#places-' + index).typeahead(null, {
+      source: engine.ttAdapter(),
+      displayKey: 'description'
+    });
+
+    // Required to bind addresspicker:selected
+    engine.bindDefaultTypeaheadEvent($('#places-' + index))
+
+    $(engine).bind('addresspicker:selected', function (event, selectedPlace) {
+      if ($('#places-' + index).val() === selectedPlace.description) {
+        $('#places-' + index + '-lon').val(selectedPlace.geometry.coordinates[0])
+        $('#places-' + index + '-lat').val(selectedPlace.geometry.coordinates[1])
+      }
+    });
   });
 
-  $('#to').typeahead(null, {
-    source: engine.ttAdapter(),
-    displayKey: 'description'
-  });
-
-  // Those 2 are required to bind addresspicker:selected
-  engine.bindDefaultTypeaheadEvent($('#from'))
-  engine.bindDefaultTypeaheadEvent($('#to'))
-
-  $(engine).bind('addresspicker:selected', function (event, selectedPlace) {
-    if ($('#from').val() === selectedPlace.description) {
-      $('#from_lon').val(selectedPlace.geometry.coordinates[0])
-      $('#from_lat').val(selectedPlace.geometry.coordinates[1])
-    }
-
-    // No else if because both input could have the same value. That would
-    // make no sense product wise, but it's a technical possibility.
-    if ($('#to').val() === selectedPlace.description) {
-      $('#to_lon').val(selectedPlace.geometry.coordinates[0])
-      $('#to_lat').val(selectedPlace.geometry.coordinates[1])
-    }
-  });
-
-  // Bootstrap tabs:
+  ///////////////////
+  // Bootstrap tabs
+  ///////////////////
   $('#kind-tabs a').click(function (e) {
     e.preventDefault()
     $(this).tab('show')

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -31,6 +31,7 @@ class AppTest < MiniTest::Test
     get "/trip", from: "Paris", to: "Berlin"
 
     assert last_response.ok?
+    assert_equal last_response.headers["Warning"], "299 hitchspots.me/trip \"Deprecated\""
   end
 
   def test_v2_trip

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -33,6 +33,12 @@ class AppTest < MiniTest::Test
     assert last_response.ok?
   end
 
+  def test_v2_trip
+    get "/v2/trip", places: { "0" => { name: "Paris" }, "1" => { name: "Berlin" } }
+
+    assert last_response.ok?
+  end
+
   def test_country
     get "/country", name: "Finland", iso_code: "FI"
 

--- a/test/coordinate_test.rb
+++ b/test/coordinate_test.rb
@@ -17,16 +17,16 @@ class CoordinateTest < Minitest::Test
   end
 
   def test_for_trip_correct
-    coords = Hitchspots::Coordinate.for_trip(Hitchspots::Place.new("Berlin"),
-                                             Hitchspots::Place.new("Paris"),
+    coords = Hitchspots::Coordinate.for_trip([Hitchspots::Place.new("Berlin"),
+                                              Hitchspots::Place.new("Paris")],
                                              api: :mapbox)
 
     assert_equal coords, JSON.parse(File.read("#{__dir__}/doubles/responses/coords_example.json"))
   end
 
   def test_for_trip_osrm
-    coords = Hitchspots::Coordinate.for_trip(Hitchspots::Place.new("Berlin"),
-                                             Hitchspots::Place.new("Paris"),
+    coords = Hitchspots::Coordinate.for_trip([Hitchspots::Place.new("Berlin"),
+                                              Hitchspots::Place.new("Paris")],
                                              api: :osrm)
 
     assert_equal coords, JSON.parse(File.read("#{__dir__}/doubles/responses/coords_example.json"))
@@ -34,8 +34,8 @@ class CoordinateTest < Minitest::Test
 
   def test_for_trip_wrong_api
     assert_raises Hitchspots::Error do
-      Hitchspots::Coordinate.for_trip(Hitchspots::Place.new("Berlin"),
-                                      Hitchspots::Place.new("Paris"),
+      Hitchspots::Coordinate.for_trip([Hitchspots::Place.new("Berlin"),
+                                       Hitchspots::Place.new("Paris")],
                                       api: :unknown)
     end
   end

--- a/test/deprecated_trip_test.rb
+++ b/test/deprecated_trip_test.rb
@@ -1,0 +1,13 @@
+require_relative "test_helper"
+require "./app"
+
+class DeprecatedTripTest < Minitest::Test
+  def test_file_name
+    trip = Hitchspots::Deprecated::Trip.new(
+      from: Hitchspots::Place.new("Berlin, city, Germany"),
+      to:   Hitchspots::Place.new("Paris, city, France")
+    )
+
+    assert_equal trip.file_name, "berlin-paris.txt"
+  end
+end

--- a/test/home_presenter_test.rb
+++ b/test/home_presenter_test.rb
@@ -4,8 +4,8 @@ require "./app"
 class HomePresenterTest < Minitest::Test
   def test_empty_trip
     home = HomePresenter.new
-    origin = home.trip.from
-    destination = home.trip.to
+    origin = home.trip.places.first
+    destination = home.trip.places.last
 
     [:name, :lat, :lon].each do |attr|
       assert_nil origin.public_send(attr)
@@ -21,12 +21,14 @@ class HomePresenterTest < Minitest::Test
   end
 
   def test_trip_with_params
-    home = HomePresenter.new(from: "Here", from_lat: "1.234", from_lon: "2.324",
-                             to:   "Da",   to_lat:   "3.456", to_lon:   "4.567")
+    home = HomePresenter.new(places: {
+                               "0" => { name: "Here", lat: "1.234", lon: "2.324" },
+                               "1" => { name: "Da",   lat: "3.456", lon: "4.567" }
+                             })
 
-    assert_equal home.trip.from.name, "Here"
-    assert_equal home.trip.from.lat,  "1.234"
-    assert_equal home.trip.from.lon,  "2.324"
+    assert_equal home.trip.places.first.name, "Here"
+    assert_equal home.trip.places.first.lat,  "1.234"
+    assert_equal home.trip.places.first.lon,  "2.324"
   end
 
   def test_country_with_params

--- a/test/trip_test.rb
+++ b/test/trip_test.rb
@@ -4,8 +4,8 @@ require "./app"
 class TripTest < Minitest::Test
   def test_file_name
     trip = Hitchspots::Trip.new(
-      from: Hitchspots::Place.new("Berlin, city, Germany"),
-      to:   Hitchspots::Place.new("Paris, city, France")
+      places: [Hitchspots::Place.new("Berlin, city, Germany"),
+               Hitchspots::Place.new("Paris, city, France")]
     )
 
     assert_equal trip.file_name, "berlin-paris.txt"

--- a/views/home.erb
+++ b/views/home.erb
@@ -15,24 +15,24 @@
       <div class="form-wrapper">
 
         <ul id="kind-tabs" class="nav nav-tabs nav-justified">
-          <li role="presentation" class="active"><a href="#trip-tab">Trip</a></li>
+          <li role="presentation" class="active"><a href="#places-tab">Trip</a></li>
           <li role="presentation"><a href="#country-tab">Country</a></li>
         </ul>
 
         <div class="tab-content home-form">
           <div role="tabpanel" class="tab-pane active" id="trip-tab">
-            <form method="GET" action="/trip">
-              <div class="form-group">
-                <label for="from">From</label>
-                <input id="from" type="text" class="form-control" name="from" placeholder="Geneva" required="true" autocomplete="off" value="<%= @home.trip.from.name %>">
-                <input id="from_lat" type="hidden" name="from_lat" value="<%= @home.trip.from.lat %>">
-                <input id="from_lon" type="hidden" name="from_lon" value="<%= @home.trip.from.lon %>">
+            <form method="GET" action="/v2/trip">
+              <div class="form-group" data-behaviour="geocode" data-place-index='0'>
+                <label for="places[0]">From</label>
+                <input id="places-0" type="text" class="form-control" name="places[0][name]" placeholder="Geneva" required="true" autocomplete="off" value="<%= @home.trip.places.first.name %>">
+                <input id="places-0-lat" type="hidden" name="places[0][lat]" value="<%= @home.trip.places.first.lat %>">
+                <input id="places-0-lon" type="hidden" name="places[0][lon]" value="<%= @home.trip.places.first.lon %>">
               </div>
-              <div class="form-group">
-                <label for="to">To</label>
-                <input id="to" type="text" class="form-control" name="to" placeholder="Zürich" required="true" autocomplete="off" value="<%= @home.trip.to.name %>">
-                <input id="to_lat" type="hidden" name="to_lat" value="<%= @home.trip.to.lat %>">
-                <input id="to_lon" type="hidden" name="to_lon" value="<%= @home.trip.to.lon %>">
+              <div class="form-group" data-behaviour="geocode" data-place-index='1'>
+                <label for="places[1]">To</label>
+                <input id="places-1" type="text" class="form-control" name="places[1][name]" placeholder="Zürich" required="true" autocomplete="off" value="<%= @home.trip.places.last.name %>">
+                <input id="places-1-lat" type="hidden" name="places[1][lat]" value="<%= @home.trip.places.last.lat %>">
+                <input id="places-1-lon" type="hidden" name="places[1][lon]" value="<%= @home.trip.places.last.lon %>">
               </div>
               <button type="submit" class="btn btn-success btn-submit" title="Send this file to your phone and import it into MAPS.me">Generate MAPS.me Bookmarks</button>
             </form>


### PR DESCRIPTION
# About

To be able to have intermediate point as discussed in #18, the API has to change.

Although I'm pretty sure nobody uses the `/trip` endpoint outside of the web UI, I don't like to break it anyway. So here is a `/v2/trip` endpoint which will allow more than 2 points for a trip.

The visual interface is not changing for now, keep only from/to in the form.