### PR TITLE
Re-encoding is no more needed, html escape still is

### DIFF
--- a/lib/db/spot.rb
+++ b/lib/db/spot.rb
@@ -86,14 +86,7 @@ module DB
     # rubocop:enable Metrics/MethodLength
 
     def sanitize_string(string)
-      re_encoded = re_encode(string)
-      CGI.escape_html(re_encoded) if re_encoded # breaks for nil values
-    end
-
-    def re_encode(string)
-      string.encode("Windows-1252").force_encoding("utf-8")
-    rescue Encoding::UndefinedConversionError
-      nil
+      CGI.escape_html(string) if string # breaks for nil values
     end
   end
 end

--- a/test/db_spot_test.rb
+++ b/test/db_spot_test.rb
@@ -6,19 +6,18 @@ class DbSpotTest < Minitest::Test
     DB::Spot::Collection.delete_many
   end
 
-  def test_re_encoding
+  def test_html_escape
     spot = DB::Spot.new(id: "1", lat: "46.7635", lon: "6.643722",
-                        location: { locality: "KÃ¶niz" },
                         description: {
                           en_UK: {
-                            description: "TimiÈ™oara is a nice place"
+                            description: "<em>I like this place</em>"
                           }
                         })
 
     sanitized = spot.data[:sanitized]
 
-    assert_equal "Köniz", sanitized[:location][:locality]
-    assert_equal "Timișoara is a nice place", sanitized[:description][:en_UK][:description]
+    assert_equal "&lt;em&gt;I like this place&lt;/em&gt;",
+                 sanitized[:description][:en_UK][:description]
   end
 
   def test_update


### PR DESCRIPTION
# About

A change has been proposed to the hitchwiki DB to fix bad encoding.

If the change is applied, that means, re-encoding is not needed anymore. html tag escaping still is
though, so let's make sure it's covered by a test.