### PR TITLE
Fix broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is very practical but hitchhikers might not have access to the Internet while they are on the road, and therefore would not be able to quickly go check if there is a good spot close to their location.
 
-Hitchspots is here to close the gap: before going on your trip, get a digest of all the spots along your route in KML format. This way, you can import this file in your favorite offline maps application, [Maps.me](https://maps.me/en/home), and have access to all the spots along your route without the need for an Internet connection.
+Hitchspots is here to close the gap: before going on your trip, get a digest of all the spots along your route in KML format. This way, you can import this file in your favorite offline maps application, [Maps.me](https://maps.me), and have access to all the spots along your route without the need for an Internet connection.
 
 ## License and Data
 

--- a/views/home.erb
+++ b/views/home.erb
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div class="home bg">
-      <h1>Get <a href="https://hitchwiki.org/maps/">Hitchwiki</a> spots into <a href="https://maps.me/en/home">MAPS.me</a></h1>
+      <h1>Get <a href="https://hitchwiki.org/maps/">Hitchwiki</a> spots into <a href="https://maps.me">MAPS.me</a></h1>
       <div class="form-wrapper">
 
         <ul id="kind-tabs" class="nav nav-tabs nav-justified">


### PR DESCRIPTION
Old url was showing whitelabel error page so fixed url.
![image](https://user-images.githubusercontent.com/7377334/159142428-38e9449d-f8d8-4c65-8eae-9af7e0f6e80a.png)
